### PR TITLE
Change URI to https://inverse.chat (full screen version of inverse)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "xmpp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "xmpp client",
   "main": "index.js",
   "author": "Alexander Schranz",
   "license": "MIT",
   "config": {
-    "serviceURL": "https://conversejs.org",
+    "serviceURL": "https://inverse.chat",
     "serviceName": "XMPP Client",
     "message": "A free and open-source XMPP chat client.",
     "popup": [],

--- a/webview.js
+++ b/webview.js
@@ -1,8 +1,9 @@
 // xmpp integration
 module.exports = (Franz, options) => {
     const getMessages = () => {
-        const directMessages = parseInt(document.querySelector('.unread-message-count').innerText, 10);
-        const indirectMessages = 0;
+        let msgContainer = document.querySelector('.contacts-tab > .msgs-indicator');
+        let directMessages = msgContainer == null ? 0 : parseInt(msgContainer.innerText, 10);
+        let indirectMessages = 0;
 
         Franz.setBadge(directMessages, indirectMessages);
     }


### PR DESCRIPTION
There is now a fullscreen version of converse available at https://inverse.chat.
This works a lot better with Franz and feels more like it supposed to. Simply replacing the domain in the package.json and adjusting the css selector in webview.js is sufficient.

If you like the changes, feel free to accept the pull request. :)